### PR TITLE
com.webos.service.battery: Fix ACG

### DIFF
--- a/files/sysbus/com.webos.service.battery.api.json
+++ b/files/sysbus/com.webos.service.battery.api.json
@@ -1,5 +1,5 @@
 {
-    "powerd.management": [
+    "batteryd.management": [
         "com.webos.service.battery/com/palm/power/battchargingStatusQuery",
         "com.webos.service.battery/com/palm/power/batterySaverOnOff",
         "com.webos.service.battery/com/palm/power/batteryStatusQuery",

--- a/files/sysbus/com.webos.service.battery.groups.json
+++ b/files/sysbus/com.webos.service.battery.groups.json
@@ -1,0 +1,4 @@
+{
+ "allowedNames": ["com.webos.service.battery"],
+ "batteryd.management": ["dev"]
+}


### PR DESCRIPTION
Seems I forgot to rename the API group, so let's tackle that too while adding the groups file.

Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 34 group(s) that appear only in api-permissions.d, consider define them in groups.d
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   powerd.management