### PR TITLE
com.webos.service.battery.perm.json: Update permissions

### DIFF
--- a/files/sysbus/com.webos.service.battery.perm.json
+++ b/files/sysbus/com.webos.service.battery.perm.json
@@ -1,9 +1,7 @@
 {
     "com.webos.service.battery": [
         "activity.operation",
-        "powerd.management",
-        "signals.all",
-        "sleep.internal",
+        "servicebus.signal",
         "sleep.management"
     ]
 }


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'powerd.management' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   com.webos.service.battery.perm.json